### PR TITLE
no java dependency and latest sbt version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install this playbook:
 
 ### `sbt_version`
 
-Default: `0.13.12`
+Default: `1.2.8`
 
 Set which version to use.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ## Which sbt version to use:
-## - 0.13.12
-sbt_version: 0.13.12
+## - 1.2.8
+sbt_version: 1.2.8
 
 ## Which environment to deploy:
 ## - devel: provision devel-time environment for developing

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,3 @@ galaxy_info:
   galaxy_tags:
     - cloud
     - system
-
-dependencies:
-  - jeffhung.java-se
-

--- a/tasks/install_from_binaries.yml
+++ b/tasks/install_from_binaries.yml
@@ -20,7 +20,7 @@
 
 - name: Unpack sbt distribution
   unarchive:
-    src:   "{{ sbt_bundle_name }}.tgz"
+    src:   "{{ sbt_cache_dir }}/{{ sbt_bundle_name }}.tgz"
     dest:  "{{ sbt_dir_base }}"
     owner: root
     group: root

--- a/tasks/install_from_binaries.yml
+++ b/tasks/install_from_binaries.yml
@@ -9,17 +9,10 @@
     sbt_bundle_name: "sbt-{{ sbt_version }}"
 - debug: var=sbt_bundle_name
 
-#- name: Load sbt binary tarbll MD5
-#  set_fact:
-#    sbt_binary_md5: "{{ item.split(': ')|last|replace(' ', '')|lower }}"
-#  with_url: [ "{{ sbt_url_base }}/{{ sbt_version }}/{{ sbt_bundle_name }}.tgz.md5" ]
-#- debug: var=sbt_binary_md5
-
 - name: Download sbt binary tarball
   get_url:
-    url: "{{ sbt_url_base }}/{{ sbt_version }}/{{ sbt_bundle_name }}.tgz"
+    url: "{{ sbt_url_base }}/{{ sbt_bundle_name }}.tgz"
     dest: "{{ sbt_cache_dir }}/{{ sbt_bundle_name }}.tgz"
-#   checksum: md5:{{ sbt_binary_md5 }}
 
 - name: Ensure {{ sbt_dir_base }} exists
   file: path={{ sbt_dir_base }} state=directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: Initiate build process
-  include: build.yml
-  when: sbt_environment == 'build'
+#- name: Initiate build process
+#  include: build.yml
+#  when: sbt_environment == 'build'
 
 - name: Initiate install process
   include: install.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-# https://dl.bintray.com/sbt/native-packages/sbt/0.13.12/sbt-0.13.12.tgz
-sbt_url_base: "https://dl.bintray.com/sbt/native-packages/sbt"
+# https://piccolo.link/sbt-1.2.8.tgz
+sbt_url_base: "https://piccolo.link"
 
 sbt_dir_base: /opt
 


### PR DESCRIPTION
sbt can be installed without java and the jeffhung/java-se isn't working properly. thats why i removed it.
I set the default version to the latest sbt version
I corrected the url to tgz file
build.yml is comment out because it does not exists